### PR TITLE
Update for compatibility with latest WireShark, and fix MSTNAK handling bug

### DIFF
--- a/mmdvm.lua
+++ b/mmdvm.lua
@@ -463,11 +463,11 @@ function p_mmdvm.dissector (buf, pkt, root)
     elseif (tostring(buf(0,6)):fromhex()) == "MSTNAK" then
 
       subtree:add(f_signature, buf(0,6))
-      info("NAK in frame" .. _number)
+      -- info("NAK in frame" .. _number)
 
       if not pkt.visited then
 
-        info("univsited NAK in frame" .. _number)
+        -- info("univsited NAK in frame" .. _number)
 
         if not state_map[_number] then
           state_map[_number] = {}
@@ -520,15 +520,17 @@ function p_mmdvm.dissector (buf, pkt, root)
         else
           if buf:len() == 10 then
             subtree:add(f_rptr_id, buf(6,4))
-            pkt.cols.info:set("MSTNAK")
+            state_map[_number]['MSG'] = "MST->RPT: MSTNAK"
           else
-             pkt.cols.info:set("MSTNAK [MALFORMED]")
+            state_map[_number]['MALFORMED'] = true
+            state_map[_number]['MSG'] = "MST->RPT: MSTNAK [MALFORMED]"
           end
+          pkt.cols.info:set(state_map[_number]['MSG'])
         end
 
       else
 
-        info("visited NAK in frame" .. _number)
+        -- info("visited NAK in frame" .. _number)
         _message = state_map[_number]['MSG']
         pkt.cols.info:set(_message)
         if not state_map[_number]['MALFORMED'] then

--- a/mmdvm.lua
+++ b/mmdvm.lua
@@ -62,7 +62,7 @@ function string.fromhex(str)
 end
 
 function round(num, precision)
-   return math.floor(num*math.pow(10,precision)+0.5) / math.pow(10,precision)
+  return math.floor(num*10^precision+0.5) / 10^precision
 end
 
 -- removes leading zeros
@@ -463,11 +463,11 @@ function p_mmdvm.dissector (buf, pkt, root)
     elseif (tostring(buf(0,6)):fromhex()) == "MSTNAK" then
 
       subtree:add(f_signature, buf(0,6))
-      -- info("NAK in frame" .. _number)
+      print("NAK in frame" .. _number)
 
       if not pkt.visited then
 
-        -- info("univsited NAK in frame" .. _number)
+        print("univsited NAK in frame" .. _number)
 
         if not state_map[_number] then
           state_map[_number] = {}
@@ -530,7 +530,7 @@ function p_mmdvm.dissector (buf, pkt, root)
 
       else
 
-        -- info("visited NAK in frame" .. _number)
+        print("visited NAK in frame" .. _number)
         _message = state_map[_number]['MSG']
         pkt.cols.info:set(_message)
         if not state_map[_number]['MALFORMED'] then


### PR DESCRIPTION
While the existing code mostly works in the current version of WireShark there are a few issues that either cause errors or outright break some scenarios.

1. The current version of LUA does not support `info()`. This was causing failures with **MSTNAK** packet processing. The fix is to use `print()`.
2. The current version of LUA does not support `math.pow()`, causing errors in calculating **BER**. The fix is to use `^` instead.
3. There was a null (nil in LUA) reference issue with **MSTNAK** packets where we sometimes did not set the message, but then tried to reference it for the info column. The logic has been updated to consistently set this.